### PR TITLE
Crawl palloliitto scripts to get all cool data for web site

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -33,6 +33,8 @@ module.exports = {
       options: {
         gamesScheduleUrl:
           "https://www.palloliitto.fi/torneopal/ajax/[torneopal:team_schedule:team=133797%26amp;season=2019%26amp;key=A4YDZ6FZ2M]",
+        scoreTableUrl:
+          "https://www.palloliitto.fi/torneopal/ajax/[torneopal:scoretable:competition=hkihl19%26amp;class=HM_5%26amp;group=1%26amp;key=A4YDZ6FZ2M]",
       },
     },
     // this (optional) plugin enables Progressive Web App + Offline functionality

--- a/plugins/gatsby-source-palloliitto/gatsby-node.js
+++ b/plugins/gatsby-source-palloliitto/gatsby-node.js
@@ -1,5 +1,5 @@
 const fetch = require("node-fetch")
-const queryString = require("query-string")
+const $ = require("cheerio")
 
 exports.sourceNodes = (
   { actions, createNodeId, createContentDigest },
@@ -10,23 +10,118 @@ exports.sourceNodes = (
   // Gatsby adds a configOption that's not needed for this plugin, delete it
   delete configOptions.plugins
 
-  // Convert the options object into a query string
-  // const apiOptions = queryString.stringify(configOptions)
-  // Join apiOptions with the Pixabay API URL
-  const apiUrl = configOptions.gamesScheduleUrl
-  // Gatsby expects sourceNodes to return a promise
-  return (
-    // Fetch a response from the apiUrl
-    fetch(apiUrl)
-      // Parse the response as JSON
-      .then(response => response.text()) // response.body())
-      // Process the JSON data into a node
-      .then(data => {
-        // For each query result (or 'hit')
-        // data.hits.forEach(photo => {
-        //   console.log("Photo data is:", photo)
-        // })
-        console.log(data)
+  const toNodeData = (data, id, type) => {
+    const content = JSON.stringify(data)
+    const nodeData = Object.assign({}, data, {
+      id: createNodeId(id),
+      parent: null,
+      children: [],
+      internal: {
+        type,
+        content,
+        contentDigest: createContentDigest(data),
+      },
+    })
+    return nodeData
+  }
+
+  const createPLNode = (url, id, type, parser) => {
+    return (
+      // Fetch a response from the apiUrl
+      fetch(url)
+        // Parse the response as JSON
+        .then(response => response.text())
+        // Process the JSON data into a node
+        .then(rawData => {
+          const html = rawData.slice(16, rawData.length - 3)
+          const data = parser(html)
+          const nodeData = toNodeData(data, id, type)
+          createNode(nodeData)
+        })
+    )
+  }
+
+  const chTxt = (el, exp) =>
+    $(el)
+      .find(exp)
+      .text()
+
+  const parseGamesSchedule = html => {
+    const $table = $("table", html)
+    const matches = Array.from(
+      $table.find("tr").map((_, tr) => {
+        const match = chTxt(tr, ".match")
+        const date = chTxt(tr, ".date")
+        const time = chTxt(tr, ".time")
+        const pitch = chTxt(tr, ".pitch")
+        const home = chTxt(tr, ".home")
+        const away = chTxt(tr, ".away")
+        const score = chTxt(tr, ".score")
+        return {
+          match,
+          date,
+          time,
+          pitch,
+          home,
+          away,
+          score,
+        }
       })
-  )
+    )
+    const result = {
+      matches,
+    }
+    return result
+  }
+
+  const parseScoreTable = html => {
+    const $table = $("table", html)
+    const competitionName = $table.find("caption > .competitionname").text()
+    const groupName = $table.find("caption > .groupname").text()
+    const teams = Array.from(
+      $table.find("tr").map((_, tr) => {
+        const team = chTxt(tr, ".team")
+        const played = chTxt(tr, ".played")
+        const wins = chTxt(tr, ".wins")
+        const draws = chTxt(tr, ".draws")
+        const losses = chTxt(tr, ".losses")
+        return {
+          team,
+          played,
+          wins,
+          draws,
+          losses,
+        }
+      })
+    )
+    const result = {
+      competitionName,
+      groupName,
+      teams,
+    }
+    return result
+  }
+
+  const fetchGamesSchedule = url =>
+    createPLNode(
+      url,
+      "palloliitto-games-schedule",
+      "PalloliittoGamesSchedule",
+      parseGamesSchedule
+    )
+
+  const fetchScoreTable = url =>
+    createPLNode(
+      url,
+      "palloliitto-score-table",
+      "PalloliittoScoreTable",
+      parseScoreTable
+    )
+
+  const { gamesScheduleUrl, scoreTableUrl } = configOptions
+
+  return Promise.all([
+    fetchGamesSchedule(gamesScheduleUrl),
+    fetchScoreTable(scoreTableUrl),
+  ])
 }

--- a/plugins/gatsby-source-palloliitto/package-lock.json
+++ b/plugins/gatsby-source-palloliitto/package-lock.json
@@ -4,15 +4,129 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@types/node": {
+      "version": "11.13.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-11.13.0.tgz",
+      "integrity": "sha512-rx29MMkRdVmzunmiA4lzBYJNnXsW/PhG4kMBy2ATsYaDjGGR75dCFEVVROKpNwlVdcUX3xxlghKQOeDPBJobng=="
+    },
+    "boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24="
+    },
+    "cheerio": {
+      "version": "1.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.2.tgz",
+      "integrity": "sha1-S59TqBsn5NXawxwP/Qz6A8xoMNs=",
+      "requires": {
+        "css-select": "~1.2.0",
+        "dom-serializer": "~0.1.0",
+        "entities": "~1.1.1",
+        "htmlparser2": "^3.9.1",
+        "lodash": "^4.15.0",
+        "parse5": "^3.0.1"
+      }
+    },
+    "css-select": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
+      "integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
+      "requires": {
+        "boolbase": "~1.0.0",
+        "css-what": "2.1",
+        "domutils": "1.5.1",
+        "nth-check": "~1.0.1"
+      }
+    },
+    "css-what": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.3.tgz",
+      "integrity": "sha512-a+EPoD+uZiNfh+5fxw2nO9QwFa6nJe2Or35fGY6Ipw1R3R4AGz1d1TEZrCegvw2YTmZ0jXirGYlzxxpYSHwpEg=="
+    },
     "decode-uri-component": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
     },
+    "dom-serializer": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.1.tgz",
+      "integrity": "sha512-l0IU0pPzLWSHBcieZbpOKgkIn3ts3vAh7ZuFyXNwJxJXk/c4Gwj9xaTJwIDVQCXawWD0qb3IzMGH5rglQaO0XA==",
+      "requires": {
+        "domelementtype": "^1.3.0",
+        "entities": "^1.1.1"
+      }
+    },
+    "domelementtype": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
+      "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w=="
+    },
+    "domhandler": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
+      "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
+      "requires": {
+        "domelementtype": "1"
+      }
+    },
+    "domutils": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
+      "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
+      "requires": {
+        "dom-serializer": "0",
+        "domelementtype": "1"
+      }
+    },
+    "entities": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
+      "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w=="
+    },
+    "htmlparser2": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.1.tgz",
+      "integrity": "sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==",
+      "requires": {
+        "domelementtype": "^1.3.1",
+        "domhandler": "^2.3.0",
+        "domutils": "^1.5.1",
+        "entities": "^1.1.1",
+        "inherits": "^2.0.1",
+        "readable-stream": "^3.1.1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+    },
+    "lodash": {
+      "version": "4.17.11",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+    },
     "node-fetch": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.3.0.tgz",
       "integrity": "sha512-MOd8pV3fxENbryESLgVIeaGKrdl+uaYhCSSVkjeOb/31/njTpcis5aWfdqgNlHIrKOLRbMnfPINPOML2CIFeXA=="
+    },
+    "nth-check": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.2.tgz",
+      "integrity": "sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==",
+      "requires": {
+        "boolbase": "~1.0.0"
+      }
+    },
+    "parse5": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-3.0.3.tgz",
+      "integrity": "sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==",
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "query-string": {
       "version": "6.4.2",
@@ -24,6 +138,21 @@
         "strict-uri-encode": "^2.0.0"
       }
     },
+    "readable-stream": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.3.0.tgz",
+      "integrity": "sha512-EsI+s3k3XsW+fU8fQACLN59ky34AZ14LoeVZpYwmZvldCFo0r0gnelwF2TcMjLor/BTL5aDJVBMkss0dthToPw==",
+      "requires": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      }
+    },
+    "safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
     "split-on-first": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-1.0.0.tgz",
@@ -33,6 +162,19 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
       "integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY="
+    },
+    "string_decoder": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.2.0.tgz",
+      "integrity": "sha512-6YqyX6ZWEYguAxgZzHGL7SsCeGx3V2TtOTqZz1xSTSWnqsbWwbptafNyvf/ACquZUXV3DANr5BDIwNYe1mN42w==",
+      "requires": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     }
   }
 }

--- a/plugins/gatsby-source-palloliitto/package.json
+++ b/plugins/gatsby-source-palloliitto/package.json
@@ -10,6 +10,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "cheerio": "^1.0.0-rc.2",
     "node-fetch": "^2.3.0",
     "query-string": "^6.4.2"
   }

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,7 +1,6 @@
 import React from "react"
 import { StaticQuery, graphql } from "gatsby"
 import Img from "gatsby-image"
-import styled from "styled-components"
 import Layout from "../components/layout"
 import SEO from "../components/seo"
 import { WidthWrapper } from "../components/common"

--- a/src/pages/otteluohjelma.js
+++ b/src/pages/otteluohjelma.js
@@ -19,6 +19,29 @@ class OtteluohjelmaPage extends React.Component {
                 }
               }
             }
+            palloliittoGamesSchedule {
+              id
+              matches {
+                match
+                date
+                time
+                pitch
+                home
+                away
+                score
+              }
+            }
+            palloliittoScoreTable {
+              competitionName
+              groupName
+              teams {
+                team
+                played
+                wins
+                draws
+                losses
+              }
+            }
           }
         `}
         render={data => (
@@ -26,6 +49,22 @@ class OtteluohjelmaPage extends React.Component {
             <SEO title="Otteluohjelma | Devisioona United" />
             <SplitLayout image={data.placeholderImage.childImageSharp.fluid}>
               <Heading>Otteluohjelma - Kausi 2019</Heading>
+              <table>
+                <thead>
+                  <tr>
+                    <th>Nro</th>
+                    <th>Pvm</th>
+                    <th>Klo</th>
+                    <th>Kenttä</th>
+                    <th>Nro</th>
+                    <th>Nro</th>
+                    <th>Nro</th>
+                  </tr>
+                </thead>
+                <tr>
+                  <td>{data.palloliittoGamesSchedule.matches[1].pitch}</td>
+                </tr>
+              </table>
             </SplitLayout>
           </Layout>
         )}


### PR DESCRIPTION
Adding to the custom palloliitto source plugin, it now crawls the scripts to get the data in a format that can be queried. Implemented score table and games schedule. Proof of concept UI in otteluohjelma page.