### PR TITLE
Fix hamburger

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "scripts": {
     "build": "gatsby build",
     "develop": "gatsby develop",
+    "develop-m": "gatsby develop -H 0.0.0.0 -p 8092",
     "format": "prettier --write src/**/*.{js,jsx}",
     "start": "npm run develop",
     "serve": "gatsby serve",

--- a/src/components/mainmenu.js
+++ b/src/components/mainmenu.js
@@ -12,7 +12,7 @@ const MainMenuWrapper = styled.div`
   position: fixed;
   height: 100%;
   width: 100%;
-  background-color: rgba(255, 255, 255, 95%);
+  background-color: rgba(255, 255, 255, 0.95);
   left: 0;
   top: 0;
   display: ${props => (props.isVisible ? "flex" : "none")};


### PR DESCRIPTION
Fixes the weird CSS bug happening in iOS Chrome and Safari when using background-color: RGBA by using opacity instead.

Also adds an NPM script that can be used to test the web site over network while still running it locally. (did not get it to work on my home network though)